### PR TITLE
Use reflection to check restricted methods

### DIFF
--- a/src/framework/GuiUnit/TestRunner.cs
+++ b/src/framework/GuiUnit/TestRunner.cs
@@ -156,8 +156,12 @@ namespace GuiUnit
 
 				try
 				{
-					foreach (string name in commandLineOptions.Parameters)
-						assemblies.Add(Assembly.LoadFile(name));
+					Type assemblyType = typeof (Assembly);
+					MethodInfo loadFileMethod = assemblyType.GetMethod ("LoadFile");
+					if (loadFileMethod != null) {
+						foreach (string name in commandLineOptions.Parameters)
+							assemblies.Add (loadFileMethod.Invoke (null, new[] { name }));
+					}
 
 					if (assemblies.Count == 0)
 						assemblies.Add(callingAssembly);

--- a/src/framework/GuiUnit/XwtMainLoopIntegration.cs
+++ b/src/framework/GuiUnit/XwtMainLoopIntegration.cs
@@ -20,11 +20,22 @@ namespace GuiUnit
 
 		public void InitializeToolkit ()
 		{
+			Type assemblyType = typeof (Assembly);
+			PropertyInfo locationProperty = assemblyType.GetProperty ("Location");
+			if (locationProperty == null)
+				throw new NotSupportedException();
+
+			MethodInfo loadFileMethod = assemblyType.GetMethod ("LoadFile");
+			if (loadFileMethod == null)
+				throw new NotSupportedException();
+
+			string assemblyDirectory = Path.GetDirectoryName ((string)locationProperty.GetValue (Application.Assembly, null));
+
 			// Firstly init Xwt
 			foreach (var impl in new [] { "Xwt.Gtk.dll", "Xwt.Mac.dll", "Xwt.Wpf.dll"}) {
-				var xwtImpl = Path.Combine (Path.GetDirectoryName (Application.Assembly.Location), impl);
+				var xwtImpl = Path.Combine (assemblyDirectory, impl);
 				if (File.Exists (xwtImpl))
-					Assembly.LoadFile (xwtImpl);
+					loadFileMethod.Invoke (null, new[] { xwtImpl });
 			}
 
 			var initMethods = Application.GetMethods (System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static);

--- a/src/framework/Internal/Reflect.cs
+++ b/src/framework/Internal/Reflect.cs
@@ -214,7 +214,8 @@ namespace NUnit.Framework.Internal
                     Console.WriteLine("Trying to call {0} without an instance", method.Name);
 				try
 				{
-					Environment.CurrentDirectory = System.IO.Path.GetDirectoryName (method.DeclaringType.Assembly.Location);
+					if (LocationProperty != null)
+						Environment.CurrentDirectory = System.IO.Path.GetDirectoryName ((string)LocationProperty.GetValue (method.DeclaringType.Assembly, null));
 
 					object result = null;
 					if (GuiUnit.TestRunner.MainLoop == null) {
@@ -243,6 +244,14 @@ namespace NUnit.Framework.Internal
 			}
 
 		    return null;
+		}
+
+		private static readonly PropertyInfo LocationProperty;
+
+		static Reflect()
+		{
+			Type assemblyType = typeof (Assembly);
+			LocationProperty = assemblyType.GetProperty ("Location");
 		}
 
 		static void Rethrow (Exception e)


### PR DESCRIPTION
`Assembly.LoadFile` and `Assembly.Location` are not present on Windows Phone. To allow us to keep our hard coded list of main loop integrations (and other support), we'll check for these methods at runtime and properties
and skip steps that aren't required/supported on Windows Phone.
