### PR TITLE
Support the current sync context as a fallback

### DIFF
--- a/src/framework/GuiUnit/SyncContextIntegration.cs
+++ b/src/framework/GuiUnit/SyncContextIntegration.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+
+namespace GuiUnit
+{
+	class SyncContextIntegration
+		: IMainLoopIntegration
+	{
+		public void InitializeToolkit()
+		{
+			this.context = SynchronizationContext.Current;
+		}
+
+		public void InvokeOnMainLoop (InvokerHelper helper)
+		{
+			this.context.Send (h => ((InvokerHelper)h).Invoke(), helper);
+		}
+
+		public void RunMainLoop()
+		{
+		}
+
+		public void Shutdown()
+		{
+		}
+
+		private SynchronizationContext context;
+	}
+}

--- a/src/framework/GuiUnit/TestRunner.cs
+++ b/src/framework/GuiUnit/TestRunner.cs
@@ -57,6 +57,7 @@ namespace GuiUnit
 				try { mainLoop = mainLoop ?? new XwtMainLoopIntegration (); } catch { }
 				try { mainLoop = mainLoop ?? new MonoMacMainLoopIntegration (); } catch { }
 				try { mainLoop = mainLoop ?? new GtkMainLoopIntegration (); } catch { }
+				mainLoop = mainLoop ?? new SyncContextIntegration();
 				return mainLoop;
 			} set {
 				mainLoop = value;


### PR DESCRIPTION
In situations where you're already running a UI (like on mobile device
test runner apps), you don't need a explicit integration and can instead
use the current sync context.
