### PR TITLE
[GuiUnit] Update numerics comparisons to work with nfloat, nuint and nint

### DIFF
--- a/src/framework/Constraints/Numerics.cs
+++ b/src/framework/Constraints/Numerics.cs
@@ -100,7 +100,7 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if the values are equal</returns>
         public static bool AreEqual(object expected, object actual, ref Tolerance tolerance)
         {
-             _double = (expected is double || actual is double);
+            _double = (expected is double || actual is double);
             if (!_double && (IntPtr.Size == 8))
                 _double = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
 

--- a/src/framework/Constraints/Numerics.cs
+++ b/src/framework/Constraints/Numerics.cs
@@ -30,9 +30,9 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class Numerics
     {
-		static Type nintType;
-		static Type nuintType;
-		static Type nfloatType;
+        static Type nintType;
+        static Type nuintType;
+        static Type nfloatType;
 
         #region Numeric Type Recognition
         /// <summary>
@@ -58,7 +58,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (obj is System.Double) return true;
                 if (obj is System.Single) return true;
-				if (obj.GetType () == Type.GetType ("System.nfloat, Xamarin.Mac")) return true;
+                if (obj.GetType () == Type.GetType ("System.nfloat, Xamarin.Mac")) return true;
             }
             return false;
         }
@@ -81,8 +81,8 @@ namespace NUnit.Framework.Constraints
                 if (obj is System.UInt64) return true;
                 if (obj is System.Int16) return true;
                 if (obj is System.UInt16) return true;
-				if (obj.GetType () == Type.GetType ("System.nint, Xamarin.Mac")) return true;
-				if (obj.GetType () == Type.GetType ("System.nuint, Xamarin.Mac")) return true;
+                if (obj.GetType () == Type.GetType ("System.nint, Xamarin.Mac")) return true;
+                if (obj.GetType () == Type.GetType ("System.nuint, Xamarin.Mac")) return true;
             }
             return false;
         }
@@ -100,49 +100,49 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if the values are equal</returns>
         public static bool AreEqual(object expected, object actual, ref Tolerance tolerance)
         {
-			bool _double = (expected is double || actual is double);
+             _double = (expected is double || actual is double);
             if (!_double && (IntPtr.Size == 8))
-				_double = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
+                _double = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
 
-			if (_double)
-				return AreEqual (Convert.ToDouble (expected), Convert.ToDouble (actual), ref tolerance);
+            if (_double)
+                return AreEqual (Convert.ToDouble (expected), Convert.ToDouble (actual), ref tolerance);
 
-			bool _float = (expected is float || actual is float);
+            bool _float = (expected is float || actual is float);
             if (!_float && (IntPtr.Size == 4))
-				_float = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
+                _float = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
 
-			if (_float)
-				return AreEqual (Convert.ToSingle (expected), Convert.ToSingle (actual), ref tolerance);
+            if (_float)
+                return AreEqual (Convert.ToSingle (expected), Convert.ToSingle (actual), ref tolerance);
 
-			if (tolerance.Mode == ToleranceMode.Ulps)
-				throw new InvalidOperationException ("Ulps may only be specified for floating point arguments");
+            if (tolerance.Mode == ToleranceMode.Ulps)
+                throw new InvalidOperationException ("Ulps may only be specified for floating point arguments");
 
-			if (expected is decimal || actual is decimal)
-				return AreEqual (Convert.ToDecimal (expected), Convert.ToDecimal (actual), tolerance);
+            if (expected is decimal || actual is decimal)
+                return AreEqual (Convert.ToDecimal (expected), Convert.ToDecimal (actual), tolerance);
 
-			bool _ulong = (expected is ulong || actual is ulong);
+            bool _ulong = (expected is ulong || actual is ulong);
             if (!_ulong && (IntPtr.Size == 8))
-				_ulong = (expected.GetType () == nuintType || actual.GetType ()== nuintType);
+                _ulong = (expected.GetType () == nuintType || actual.GetType ()== nuintType);
 
-			if (_ulong)
-				return AreEqual (Convert.ToUInt64 (expected), Convert.ToUInt64 (actual), tolerance);
+            if (_ulong)
+                return AreEqual (Convert.ToUInt64 (expected), Convert.ToUInt64 (actual), tolerance);
 
-			bool _long = (expected is long || actual is long);
+            bool _long = (expected is long || actual is long);
             if (!_long && (IntPtr.Size == 8))
-				_long = (expected.GetType () == nintType || actual.GetType () == nintType);
+                _long = (expected.GetType () == nintType || actual.GetType () == nintType);
 
-			if (_long)
-				return AreEqual (Convert.ToInt64 (expected), Convert.ToInt64 (actual), tolerance);
+            if (_long)
+                return AreEqual (Convert.ToInt64 (expected), Convert.ToInt64 (actual), tolerance);
 
-			bool _uint = (expected is uint || actual is uint);
+            bool _uint = (expected is uint || actual is uint);
             if (!_uint && (IntPtr.Size == 4))
-				_uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
+                _uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
 
-			if (_uint)
-				return AreEqual (Convert.ToUInt32 (expected), Convert.ToUInt32 (actual), tolerance);
+            if (_uint)
+                return AreEqual (Convert.ToUInt32 (expected), Convert.ToUInt32 (actual), tolerance);
 
-			// int or nint on 32bits archs
-			return AreEqual (Convert.ToInt32 (expected), Convert.ToInt32 (actual), tolerance);
+            // int or nint on 32bits archs
+            return AreEqual (Convert.ToInt32 (expected), Convert.ToInt32 (actual), tolerance);
         }
 
         private static bool AreEqual(double expected, double actual, ref Tolerance tolerance)
@@ -379,45 +379,45 @@ namespace NUnit.Framework.Constraints
         /// <returns>The relationship of the values to each other</returns>
         public static int Compare(object expected, object actual)
         {
-			if (!IsNumericType (expected) || !IsNumericType (actual))
-				throw new ArgumentException ("Both arguments must be numeric");
+            if (!IsNumericType (expected) || !IsNumericType (actual))
+                throw new ArgumentException ("Both arguments must be numeric");
 
-			if (IsFloatingPointNumeric (expected) || IsFloatingPointNumeric (actual))
-				return Convert.ToDouble (expected).CompareTo (Convert.ToDouble (actual));
+            if (IsFloatingPointNumeric (expected) || IsFloatingPointNumeric (actual))
+                return Convert.ToDouble (expected).CompareTo (Convert.ToDouble (actual));
 
-			if (expected is decimal || actual is decimal)
-				return Convert.ToDecimal (expected).CompareTo (Convert.ToDecimal (actual));
+            if (expected is decimal || actual is decimal)
+                return Convert.ToDecimal (expected).CompareTo (Convert.ToDecimal (actual));
 
-			bool _ulong = (expected is ulong || actual is ulong);
+            bool _ulong = (expected is ulong || actual is ulong);
             if (!_ulong && (IntPtr.Size == 8))
-				_ulong = (expected.GetType () == nuintType || actual.GetType () == nuintType);
+                _ulong = (expected.GetType () == nuintType || actual.GetType () == nuintType);
 
-			if (_ulong)
-				return Convert.ToUInt64 (expected).CompareTo (Convert.ToUInt64 (actual));
+            if (_ulong)
+                return Convert.ToUInt64 (expected).CompareTo (Convert.ToUInt64 (actual));
 
-			bool _long = (expected is long || actual is long);
+            bool _long = (expected is long || actual is long);
             if (!_long && (IntPtr.Size == 8))
-				_long = (expected.GetType () == nintType || actual.GetType () == nintType);
+                _long = (expected.GetType () == nintType || actual.GetType () == nintType);
 
-			if (_long)
-				return Convert.ToInt64 (expected).CompareTo (Convert.ToInt64 (actual));
+            if (_long)
+                return Convert.ToInt64 (expected).CompareTo (Convert.ToInt64 (actual));
 
-			bool _uint = (expected is uint || actual is uint);
+            bool _uint = (expected is uint || actual is uint);
             if (!_uint && (IntPtr.Size == 4))
-				_uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
+                _uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
 
-			if (_uint)
-				return Convert.ToUInt32 (expected).CompareTo (Convert.ToUInt32 (actual));
+            if (_uint)
+                return Convert.ToUInt32 (expected).CompareTo (Convert.ToUInt32 (actual));
 
-			return Convert.ToInt32 (expected).CompareTo (Convert.ToInt32 (actual));
+            return Convert.ToInt32 (expected).CompareTo (Convert.ToInt32 (actual));
         }
         #endregion
 
         static Numerics()
         {
-			nintType = Type.GetType ("System.nint, Xamarin.Mac");
-			nuintType = Type.GetType ("System.nuint, Xamarin.Mac");
-			nfloatType = Type.GetType ("System.nfloat, Xamarin.Mac");
+            nintType = Type.GetType ("System.nint, Xamarin.Mac");
+            nuintType = Type.GetType ("System.nuint, Xamarin.Mac");
+            nfloatType = Type.GetType ("System.nfloat, Xamarin.Mac");
         }
     }
 }

--- a/src/framework/Constraints/Numerics.cs
+++ b/src/framework/Constraints/Numerics.cs
@@ -30,6 +30,10 @@ namespace NUnit.Framework.Constraints
     /// </summary>
     public class Numerics
     {
+		static Type nintType;
+		static Type nuintType;
+		static Type nfloatType;
+
         #region Numeric Type Recognition
         /// <summary>
         /// Checks the type of the object, returning true if
@@ -54,6 +58,7 @@ namespace NUnit.Framework.Constraints
             {
                 if (obj is System.Double) return true;
                 if (obj is System.Single) return true;
+				if (obj.GetType () == Type.GetType ("System.nfloat, Xamarin.Mac")) return true;
             }
             return false;
         }
@@ -76,6 +81,8 @@ namespace NUnit.Framework.Constraints
                 if (obj is System.UInt64) return true;
                 if (obj is System.Int16) return true;
                 if (obj is System.UInt16) return true;
+				if (obj.GetType () == Type.GetType ("System.nint, Xamarin.Mac")) return true;
+				if (obj.GetType () == Type.GetType ("System.nuint, Xamarin.Mac")) return true;
             }
             return false;
         }
@@ -93,28 +100,49 @@ namespace NUnit.Framework.Constraints
         /// <returns>True if the values are equal</returns>
         public static bool AreEqual(object expected, object actual, ref Tolerance tolerance)
         {
-            if (expected is double || actual is double)
-                return AreEqual(Convert.ToDouble(expected), Convert.ToDouble(actual), ref tolerance);
+			bool _double = (expected is double || actual is double);
+            if (!_double && (IntPtr.Size == 8))
+				_double = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
 
-            if (expected is float || actual is float)
-                return AreEqual(Convert.ToSingle(expected), Convert.ToSingle(actual), ref tolerance);
+			if (_double)
+				return AreEqual (Convert.ToDouble (expected), Convert.ToDouble (actual), ref tolerance);
 
-            if (tolerance.Mode == ToleranceMode.Ulps)
-                throw new InvalidOperationException("Ulps may only be specified for floating point arguments");
+			bool _float = (expected is float || actual is float);
+            if (!_float && (IntPtr.Size == 4))
+				_float = (expected.GetType () == nfloatType || actual.GetType () == nfloatType);
 
-            if (expected is decimal || actual is decimal)
-                return AreEqual(Convert.ToDecimal(expected), Convert.ToDecimal(actual), tolerance);
+			if (_float)
+				return AreEqual (Convert.ToSingle (expected), Convert.ToSingle (actual), ref tolerance);
 
-            if (expected is ulong || actual is ulong)
-                return AreEqual(Convert.ToUInt64(expected), Convert.ToUInt64(actual), tolerance);
+			if (tolerance.Mode == ToleranceMode.Ulps)
+				throw new InvalidOperationException ("Ulps may only be specified for floating point arguments");
 
-            if (expected is long || actual is long)
-                return AreEqual(Convert.ToInt64(expected), Convert.ToInt64(actual), tolerance);
+			if (expected is decimal || actual is decimal)
+				return AreEqual (Convert.ToDecimal (expected), Convert.ToDecimal (actual), tolerance);
 
-            if (expected is uint || actual is uint)
-                return AreEqual(Convert.ToUInt32(expected), Convert.ToUInt32(actual), tolerance);
+			bool _ulong = (expected is ulong || actual is ulong);
+            if (!_ulong && (IntPtr.Size == 8))
+				_ulong = (expected.GetType () == nuintType || actual.GetType ()== nuintType);
 
-            return AreEqual(Convert.ToInt32(expected), Convert.ToInt32(actual), tolerance);
+			if (_ulong)
+				return AreEqual (Convert.ToUInt64 (expected), Convert.ToUInt64 (actual), tolerance);
+
+			bool _long = (expected is long || actual is long);
+            if (!_long && (IntPtr.Size == 8))
+				_long = (expected.GetType () == nintType || actual.GetType () == nintType);
+
+			if (_long)
+				return AreEqual (Convert.ToInt64 (expected), Convert.ToInt64 (actual), tolerance);
+
+			bool _uint = (expected is uint || actual is uint);
+            if (!_uint && (IntPtr.Size == 4))
+				_uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
+
+			if (_uint)
+				return AreEqual (Convert.ToUInt32 (expected), Convert.ToUInt32 (actual), tolerance);
+
+			// int or nint on 32bits archs
+			return AreEqual (Convert.ToInt32 (expected), Convert.ToInt32 (actual), tolerance);
         }
 
         private static bool AreEqual(double expected, double actual, ref Tolerance tolerance)
@@ -351,30 +379,45 @@ namespace NUnit.Framework.Constraints
         /// <returns>The relationship of the values to each other</returns>
         public static int Compare(object expected, object actual)
         {
-            if (!IsNumericType(expected) || !IsNumericType(actual))
-                throw new ArgumentException("Both arguments must be numeric");
+			if (!IsNumericType (expected) || !IsNumericType (actual))
+				throw new ArgumentException ("Both arguments must be numeric");
 
-            if (IsFloatingPointNumeric(expected) || IsFloatingPointNumeric(actual))
-                return Convert.ToDouble(expected).CompareTo(Convert.ToDouble(actual));
+			if (IsFloatingPointNumeric (expected) || IsFloatingPointNumeric (actual))
+				return Convert.ToDouble (expected).CompareTo (Convert.ToDouble (actual));
 
-            if (expected is decimal || actual is decimal)
-                return Convert.ToDecimal(expected).CompareTo(Convert.ToDecimal(actual));
+			if (expected is decimal || actual is decimal)
+				return Convert.ToDecimal (expected).CompareTo (Convert.ToDecimal (actual));
 
-            if (expected is ulong || actual is ulong)
-                return Convert.ToUInt64(expected).CompareTo(Convert.ToUInt64(actual));
+			bool _ulong = (expected is ulong || actual is ulong);
+            if (!_ulong && (IntPtr.Size == 8))
+				_ulong = (expected.GetType () == nuintType || actual.GetType () == nuintType);
 
-            if (expected is long || actual is long)
-                return Convert.ToInt64(expected).CompareTo(Convert.ToInt64(actual));
+			if (_ulong)
+				return Convert.ToUInt64 (expected).CompareTo (Convert.ToUInt64 (actual));
 
-            if (expected is uint || actual is uint)
-                return Convert.ToUInt32(expected).CompareTo(Convert.ToUInt32(actual));
+			bool _long = (expected is long || actual is long);
+            if (!_long && (IntPtr.Size == 8))
+				_long = (expected.GetType () == nintType || actual.GetType () == nintType);
 
-            return Convert.ToInt32(expected).CompareTo(Convert.ToInt32(actual));
+			if (_long)
+				return Convert.ToInt64 (expected).CompareTo (Convert.ToInt64 (actual));
+
+			bool _uint = (expected is uint || actual is uint);
+            if (!_uint && (IntPtr.Size == 4))
+				_uint = (expected.GetType () == nuintType || actual.GetType () == nuintType);
+
+			if (_uint)
+				return Convert.ToUInt32 (expected).CompareTo (Convert.ToUInt32 (actual));
+
+			return Convert.ToInt32 (expected).CompareTo (Convert.ToInt32 (actual));
         }
         #endregion
 
-        private Numerics()
+        static Numerics()
         {
+			nintType = Type.GetType ("System.nint, Xamarin.Mac");
+			nuintType = Type.GetType ("System.nuint, Xamarin.Mac");
+			nfloatType = Type.GetType ("System.nfloat, Xamarin.Mac");
         }
     }
 }

--- a/src/framework/GuiUnit/AdditionalAsserts.cs
+++ b/src/framework/GuiUnit/AdditionalAsserts.cs
@@ -99,6 +99,54 @@ namespace NUnit.Framework
 			Assert.That(actual, Is.InstanceOf<T> ());
 		}
 
+		#region IsInstanceOfType
+		/// <summary>
+		/// Verifies that the object that is passed in is equal to <code>null</code>
+		/// If the object is not <code>null</code> then an <see cref="AssertionException"/>
+		/// is thrown.
+		/// </summary>
+		/// <param name="anObject">The object that is to be tested</param>
+		/// <param name="message">The message to display in case of failure</param>
+		/// <param name="args">Array of objects to be used in formatting the message</param>
+		public static void IsInstanceOfType (object anObject, string message, params object [] args)
+		{
+			Assert.That (anObject, Is.Null, message, args);
+		}
+
+		/// <summary>
+		/// Asserts that an object is an instance of a given type.
+		/// </summary>
+		/// <param name="expected">The expected Type</param>
+		/// <param name="actual">The object being examined</param>
+		public static void IsInstanceOfType (System.Type expected, object actual)
+		{
+			IsInstanceOfType (expected, actual, string.Empty, null);
+		}
+
+		/// <summary>
+		/// Asserts that an object is an instance of a given type.
+		/// </summary>
+		/// <param name="expected">The expected Type</param>
+		/// <param name="actual">The object being examined</param>
+		/// <param name="message">A message to display in case of failure</param>
+		public static void IsInstanceOfType (System.Type expected, object actual, string message)
+		{
+			IsInstanceOfType (expected, actual, message, null);
+		}
+
+		/// <summary>
+		/// Asserts that an object is an instance of a given type.
+		/// </summary>
+		/// <param name="expected">The expected Type</param>
+		/// <param name="actual">The object being examined</param>
+		/// <param name="message">A message to display in case of failure</param>
+		/// <param name="args">An array of objects to be used in formatting the message</param>
+		public static void IsInstanceOfType (System.Type expected, object actual, string message, params object [] args)
+		{
+			Assert.That (actual.GetType (), Is.EqualTo (expected), message, args);
+		}
+		#endregion
+
 		#endregion
 	}
 }


### PR DESCRIPTION
Some assert comparisons will fail to compare them correctly without the change, such as:

nint foo = 3;
Assert.That (foo, Is.EqualTo (3));

Should pass, but fails without the change.