### PR TITLE
Print the full test name when showing labels.

### DIFF
--- a/src/framework/GuiUnit/TestRunner.cs
+++ b/src/framework/GuiUnit/TestRunner.cs
@@ -394,7 +394,7 @@ namespace GuiUnit
 		public void TestStarted(ITest test)
 		{
 			if (commandLineOptions.LabelTestsInOutput)
-				writer.WriteLine("***** {0}", test.Name);
+				writer.WriteLine("***** {0}", test.FullName);
 			listener.TestStarted (test);
 		}
 


### PR DESCRIPTION
Printing just the test name is confusing, because there can be multiple tests
with the same name.