### PR TITLE
Print errors at the end.

### DIFF
--- a/src/framework/Runner/ResultReporter.cs
+++ b/src/framework/Runner/ResultReporter.cs
@@ -65,11 +65,11 @@ namespace NUnitLite.Runner
         {
             PrintSummaryReport();
 
-            if (summary.FailureCount > 0 || summary.ErrorCount > 0)
-                PrintErrorReport();
-
             if (summary.NotRunCount > 0)
                 PrintNotRunReport();
+
+            if (summary.FailureCount > 0 || summary.ErrorCount > 0)
+                PrintErrorReport();
 
             //if (commandLineOptions.Full)
             //    PrintFullReport(result);


### PR DESCRIPTION
This way I don't have to scroll over a potentially large list of tests that
weren't run to find the tests I'm interested in.