### PR TITLE
Report exit code when shutting down toolkit

### DIFF
--- a/src/framework/GuiUnit/GtkMainLoopIntegration.cs
+++ b/src/framework/GuiUnit/GtkMainLoopIntegration.cs
@@ -60,7 +60,7 @@ namespace GuiUnit
 			Application.GetMethod ("Run").Invoke (null, null);
 		}
 
-		public void Shutdown ()
+		public void Shutdown (int exitCode)
 		{
 			Application.GetMethod ("Quit").Invoke (null, null);
 		}

--- a/src/framework/GuiUnit/IMainLoopIntegration.cs
+++ b/src/framework/GuiUnit/IMainLoopIntegration.cs
@@ -7,7 +7,7 @@ namespace GuiUnit
 		void InitializeToolkit ();
 		void InvokeOnMainLoop (InvokerHelper helper);
 		void RunMainLoop ();
-		void Shutdown ();
+		void Shutdown (int exitCode);
 	}
 }
 

--- a/src/framework/GuiUnit/MonoMacMainLoopIntegration.cs
+++ b/src/framework/GuiUnit/MonoMacMainLoopIntegration.cs
@@ -56,7 +56,7 @@ namespace GuiUnit
 			Application.GetMethod ("Run").Invoke (SharedApplication, null);
 		}
 
-		public void Shutdown ()
+		public void Shutdown (int exitCode)
 		{
 			Application.GetMethod ("Terminate").Invoke (SharedApplication, new [] { SharedApplication });
 		}

--- a/src/framework/GuiUnit/TestRunner.cs
+++ b/src/framework/GuiUnit/TestRunner.cs
@@ -82,6 +82,8 @@ namespace GuiUnit
 
 		private ITestAssemblyRunner runner;
 
+		private bool finished;
+
 		#region Constructors
 
 		/// <summary>
@@ -228,7 +230,8 @@ namespace GuiUnit
 								} catch (Exception ex) {
 									Console.WriteLine ("Unexpected error while running the tests: {0}", ex);
 								} finally {
-									Shutdown ();
+									FinishTestExecution();
+									Shutdown();
 								}
 							});
 							MainLoop.RunMainLoop ();
@@ -246,24 +249,34 @@ namespace GuiUnit
 					ExitCode = 1;
 				}
 				finally
-				{
-					if (commandLineOptions.OutFile == null)
-					{
-						if (commandLineOptions.Wait)
-						{
-							Console.WriteLine("Press Enter key to continue . . .");
-							Console.ReadLine();
-						}
-					}
-					else
-					{
-						writer.Close();
-					}
-				}
-			}
+                {
+                    FinishTestExecution();
+                }
+            }
 		}
 
-		static void Shutdown ()
+        private void FinishTestExecution()
+        {
+			if (finished)
+				return;
+
+			finished = true;
+
+			if (commandLineOptions.OutFile == null)
+            {
+                if (commandLineOptions.Wait)
+                {
+                    Console.WriteLine("Press Enter key to continue . . .");
+                    Console.ReadLine();
+                }
+            }
+            else
+            {
+                writer.Close();
+            }
+        }
+
+        static void Shutdown ()
 		{
 			// Run the shutdown method on the main thread
 			var helper = new InvokerHelper {
@@ -275,7 +288,7 @@ namespace GuiUnit
 						Console.WriteLine ("Unexpected error during `BeforeShutdown`: {0}", ex);
 						ExitCode = 1;
 					} finally {
-						MainLoop.Shutdown ();
+						MainLoop.Shutdown (ExitCode);
 					}
 					return null;
 				}

--- a/src/framework/GuiUnit/XwtMainLoopIntegration.cs
+++ b/src/framework/GuiUnit/XwtMainLoopIntegration.cs
@@ -67,9 +67,13 @@ namespace GuiUnit
 			Application.GetMethod ("Run").Invoke (null, null);
 		}
 
-		public void Shutdown ()
+		public void Shutdown (int exitCode)
 		{
-			Application.GetMethod ("Exit").Invoke (null, null);
+			var method = Application.GetMethod("Exit", new Type[] { typeof(int) });
+			if (method != null)
+				method.Invoke(null, new object[] { exitCode });
+			else
+				Application.GetMethod("Exit").Invoke(null, null);
 		}
 	}
 }


### PR DESCRIPTION
That's required for Xamarin.Mac, since it needs to call
exit(code) to report the code